### PR TITLE
Add icon support for JSON

### DIFF
--- a/icon_themes/material-icon-theme.json
+++ b/icon_themes/material-icon-theme.json
@@ -39,6 +39,7 @@
         "image": { "path": "./icons/image.svg" },
         "java": { "path": "./icons/java.svg" },
         "javascript": { "path": "./icons/javascript.svg" },
+        "json": { "path": "./icons/json.svg" },
         "julia": { "path": "./icons/julia.svg" },
         "kotlin": { "path": "./icons/kotlin.svg" },
         "lock": { "path": "./icons/lock.svg" },


### PR DESCRIPTION
This PR adds icon support for `JSON` file. Also addresses #10. While, there is alreay `json.svg` file in `icons` folder there is no support for it.

`JSON` key has been already added on core via this PR [24432](https://github.com/zed-industries/zed/pull/24432)