### PR TITLE
Fix processing of folder icon clones

### DIFF
--- a/icon_themes/material-icon-theme.json
+++ b/icon_themes/material-icon-theme.json
@@ -14468,36 +14468,36 @@
           "expanded": "./icons/folder-snapcraft-open.svg"
         },
         "dev": {
-          "collapsed": "./icons/folder-development.svg",
-          "expanded": "./icons/folder-development-open.svg"
+          "collapsed": "./icons/folder-development.clone.svg",
+          "expanded": "./icons/folder-development-open.clone.svg"
         },
         ".dev": {
-          "collapsed": "./icons/folder-development.svg",
-          "expanded": "./icons/folder-development-open.svg"
+          "collapsed": "./icons/folder-development.clone.svg",
+          "expanded": "./icons/folder-development-open.clone.svg"
         },
         "_dev": {
-          "collapsed": "./icons/folder-development.svg",
-          "expanded": "./icons/folder-development-open.svg"
+          "collapsed": "./icons/folder-development.clone.svg",
+          "expanded": "./icons/folder-development-open.clone.svg"
         },
         "__dev__": {
-          "collapsed": "./icons/folder-development.svg",
-          "expanded": "./icons/folder-development-open.svg"
+          "collapsed": "./icons/folder-development.clone.svg",
+          "expanded": "./icons/folder-development-open.clone.svg"
         },
         "development": {
-          "collapsed": "./icons/folder-development.svg",
-          "expanded": "./icons/folder-development-open.svg"
+          "collapsed": "./icons/folder-development.clone.svg",
+          "expanded": "./icons/folder-development-open.clone.svg"
         },
         ".development": {
-          "collapsed": "./icons/folder-development.svg",
-          "expanded": "./icons/folder-development-open.svg"
+          "collapsed": "./icons/folder-development.clone.svg",
+          "expanded": "./icons/folder-development-open.clone.svg"
         },
         "_development": {
-          "collapsed": "./icons/folder-development.svg",
-          "expanded": "./icons/folder-development-open.svg"
+          "collapsed": "./icons/folder-development.clone.svg",
+          "expanded": "./icons/folder-development-open.clone.svg"
         },
         "__development__": {
-          "collapsed": "./icons/folder-development.svg",
-          "expanded": "./icons/folder-development-open.svg"
+          "collapsed": "./icons/folder-development.clone.svg",
+          "expanded": "./icons/folder-development-open.clone.svg"
         },
         "flutter": {
           "collapsed": "./icons/folder-flutter.svg",


### PR DESCRIPTION
This PR fixes the build script for folder icons.
In the Material Icon Theme, we use a concept where [existing folder icons can be cloned](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md#cloning-workflow) into new icons by reusing a base icon and applying a new color. This approach makes it much easier to create variations of icons that only differ by color.

Until now, this cloning step was not handled by the build script. This PR adds the missing logic, ensuring that cloned folder icons are correctly generated.

I also tested the preview build today, and with this fix, all folder icons are now displayed correctly:

<img width="322" height="486" alt="image" src="https://github.com/user-attachments/assets/5443a53d-69dd-4390-9837-105be24fb332" />
