### PR TITLE
Add meson.options to Meson icon mapping

### DIFF
--- a/icon_themes/material-icon-theme.json
+++ b/icon_themes/material-icon-theme.json
@@ -19137,6 +19137,8 @@
         "MESON.BUILD": "meson",
         "meson_options.txt": "meson",
         "MESON_OPTIONS.TXT": "meson",
+        "meson.options": "meson",
+        "MESON.OPTIONS": "meson",
         ".czrc": "commitizen",
         ".CZRC": "commitizen",
         ".cz.json": "commitizen",


### PR DESCRIPTION
I recently switched from using `meson_options.txt` to `meson.options` and noticed that this file doesn't have Meson's icon. For context, Meson seems to have switched from `meson_options.txt` to `meson.options` in version 1.1 as stated in [their documentation](https://mesonbuild.com/Build-options.html), so this file should, indeed, be mapped to Meson.

<img width="1664" height="586" alt="image" src="https://github.com/user-attachments/assets/d182d818-3ce1-481e-87ed-3a7d56d7e005" />

This PR does just that. Here's the before & after:

<img width="439" height="147" alt="image" src="https://github.com/user-attachments/assets/c4da8860-eddf-4629-b5e0-5aa6c1dad464" />