### PR TITLE
feat: add support for multiple icon pack themes

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -1,17 +1,29 @@
 import { writeFileSync } from "node:fs";
-import { generateManifest } from "material-icon-theme";
+import { generateManifest, type IconPackValue } from "material-icon-theme";
 import { join } from "node:path";
 import { getTheme } from "./theme";
 import fs from "node:fs";
 
-const manifest = generateManifest();
-const zedIconTheme = getTheme(manifest);
+// Icon packs to generate themes for
+const iconPacks: IconPackValue[] = [
+  "", // Default (no specific pack)
+  "nest", // NestJS
+  "angular", // Angular
+  "react", // React
+  "vue", // Vue
+];
+
+// Generate themes for each icon pack
+const themes = iconPacks.map((pack) => {
+  const manifest = generateManifest({ activeIconPack: pack });
+  return getTheme(manifest, pack);
+});
 
 const zedManifest = {
   $schema: "https://zed.dev/schema/icon_themes/v0.2.0.json",
   name: "Material Icon Theme",
   author: "Zed Industries",
-  themes: [zedIconTheme],
+  themes,
 };
 
 writeFileSync(

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,4 +1,4 @@
-import type { Manifest } from "material-icon-theme";
+import type { Manifest, IconPackValue } from "material-icon-theme";
 import type { IconTheme } from "./types/icon-theme";
 
 const keyMapping: { [key: string]: string } = {
@@ -10,7 +10,24 @@ const keyMapping: { [key: string]: string } = {
   template: "templ",
 };
 
-export const getTheme = (manifest: Manifest): IconTheme => {
+const packDisplayNames: Record<string, string> = {
+  "": "Material Icon Theme",
+  nest: "Material Icon Theme (NestJS)",
+  angular: "Material Icon Theme (Angular)",
+  react: "Material Icon Theme (React)",
+  vue: "Material Icon Theme (Vue)",
+  angular_ngrx: "Material Icon Theme (Angular + NgRx)",
+  react_redux: "Material Icon Theme (React + Redux)",
+  vue_vuex: "Material Icon Theme (Vue + Vuex)",
+  qwik: "Material Icon Theme (Qwik)",
+  roblox: "Material Icon Theme (Roblox)",
+  bashly: "Material Icon Theme (Bashly)",
+};
+
+export const getTheme = (
+  manifest: Manifest,
+  iconPack: IconPackValue = "",
+): IconTheme => {
   const transformedIconDefinitions = Object.fromEntries(
     Object.entries(manifest.iconDefinitions ?? {}).map(([key, value]) => [
       keyMapping[key] || key, // Apply key renaming if a mapping exists
@@ -18,18 +35,18 @@ export const getTheme = (manifest: Manifest): IconTheme => {
         // Replace iconPath to point to the icons directory of this theme
         path: value.iconPath.replace("./../icons/", "./icons/"),
       },
-    ])
+    ]),
   );
 
   const fileIconDefinitions = Object.fromEntries(
     Object.entries(transformedIconDefinitions).filter(
-      ([key]) => !key.startsWith("folder")
-    )
+      ([key]) => !key.startsWith("folder"),
+    ),
   );
   const folderIconDefinitions = Object.fromEntries(
     Object.entries(transformedIconDefinitions).filter(([key]) =>
-      key.startsWith("folder")
-    )
+      key.startsWith("folder"),
+    ),
   );
 
   /**
@@ -50,8 +67,9 @@ export const getTheme = (manifest: Manifest): IconTheme => {
       }
 
       // Add titlecase variant for file stems
-      if (!key.startsWith('.')) {
-        const titleCase = key.charAt(0).toUpperCase() + key.slice(1).toLowerCase();
+      if (!key.startsWith(".")) {
+        const titleCase =
+          key.charAt(0).toUpperCase() + key.slice(1).toLowerCase();
         acc[titleCase] = value;
       }
 
@@ -63,21 +81,25 @@ export const getTheme = (manifest: Manifest): IconTheme => {
   const named_directory_icons: IconTheme["named_directory_icons"] = {};
 
   // Process folder name mappings from the manifest
-  Object.entries(manifest.folderNames ?? {}).forEach(([folderName, iconKey]) => {
-    const collapsedIcon = folderIconDefinitions[iconKey];
-    const expandedIconKey = manifest.folderNamesExpanded?.[folderName];
-    const expandedIcon = expandedIconKey ? folderIconDefinitions[expandedIconKey] : collapsedIcon;
+  Object.entries(manifest.folderNames ?? {}).forEach(
+    ([folderName, iconKey]) => {
+      const collapsedIcon = folderIconDefinitions[iconKey];
+      const expandedIconKey = manifest.folderNamesExpanded?.[folderName];
+      const expandedIcon = expandedIconKey
+        ? folderIconDefinitions[expandedIconKey]
+        : collapsedIcon;
 
-    if (collapsedIcon) {
-      named_directory_icons[folderName] = {
-        collapsed: collapsedIcon.path,
-        expanded: expandedIcon?.path || collapsedIcon.path,
-      };
-    }
-  });
+      if (collapsedIcon) {
+        named_directory_icons[folderName] = {
+          collapsed: collapsedIcon.path,
+          expanded: expandedIcon?.path || collapsedIcon.path,
+        };
+      }
+    },
+  );
 
   return {
-    name: "Material Icon Theme",
+    name: packDisplayNames[iconPack] || `Material Icon Theme (${iconPack})`,
     appearance: "dark",
     file_icons: fileIconDefinitions,
     directory_icons: {


### PR DESCRIPTION
## Summary

This PR adds support for generating multiple icon theme variants based on different icon packs from material-icon-theme.

## Problem

Currently, the extension only generates a single theme with the default icon pack. Users who prefer framework-specific icons (React, Angular, Vue, NestJS) have no way to use them.

## Solution

Modified the build process to generate 5 theme variants:
- Material Icon Theme (default)
- Material Icon Theme (NestJS)
- Material Icon Theme (Angular)
- Material Icon Theme (React)
- Material Icon Theme (Vue)

## Changes

- `src/build.ts`: Generate manifests for each icon pack
- `src/theme.ts`: Add pack-specific theme names and accept iconPack parameter

## Testing

1. Run `bun run build`
2. Install the extension in Zed (zed: install dev extension)
3. Open command palette → "theme: select icon theme"
4. Verify all 5 variants appear and work correctly
